### PR TITLE
feat: add activation properties to application registry schema

### DIFF
--- a/application-registry.json
+++ b/application-registry.json
@@ -91,9 +91,6 @@
   "activation": {
     "type": "object",
     "properties": {
-      "enabled": {
-        "type": "boolean"
-      },
       "roles": {
         "type": "array",
         "items": {
@@ -106,8 +103,7 @@
           "type": "string"
         }
       }
-    },
-    "required": ["enabled"]
+    }
   },
   "required": [
     "iconName",

--- a/application-registry.json
+++ b/application-registry.json
@@ -88,6 +88,27 @@
   "customConfiguration": {
     "type": "object"
   },
+  "activation": {
+    "type": "object",
+    "properties": {
+      "enabled": {
+        "type": "boolean"
+      },
+      "roles": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "attributes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "required": ["enabled"]
+  },
   "required": [
     "iconName",
     "isPlatform",


### PR DESCRIPTION
This adds the new optional `activation` property so that we can switch over to using that and remove the old ones.

I went with `enabled` instead of `disabled` to follow what we already have for the other ones. I'm open to discuss that though 🙂 